### PR TITLE
fix: correct encode null values

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
         image: cassandra
         ports:
           - 9042:9042
-        options: --health-cmd "cqlsh --debug" --health-interval 5s --health-retries 10
+        options: --health-cmd "cqlsh --debug" --health-interval 5s --health-retries 20
     strategy:
       fail-fast: false
       matrix:

--- a/src/ecql_frame.erl
+++ b/src/ecql_frame.erl
@@ -437,7 +437,7 @@ serialize_batch_query_values([H|_] = Values) when is_tuple(H) ->
     ValuesBin = << <<(serialize_string(Name))/binary, (serialize_bytes(Val))/binary>> || {Name, Val} <- Values >>,
     << (length(Values)):?short, ValuesBin/binary>>;
 
-serialize_batch_query_values([H|_] = Values) when is_binary(H) ->
+serialize_batch_query_values([H|_] = Values) when is_binary(H) orelse H =:= null ->
     ValuesBin = << <<(serialize_bytes(Val))/binary>> || Val <- Values >>,
     << (length(Values)):?short, ValuesBin/binary>>.
 
@@ -464,7 +464,7 @@ serialize_parameter(values, [H |_] = Vals) when is_tuple(H) ->
     Bin = << <<(serialize_string(Name))/binary, (serialize_bytes(Val))/binary>> || {Name, Val} <- Vals >>,
     <<(length(Vals)):?short, Bin/binary>>;
 
-serialize_parameter(values, [H |_] = Vals) when is_binary(H) ->
+serialize_parameter(values, [H |_] = Vals) when is_binary(H) orelse H =:= null ->
     Bin = << <<(serialize_bytes(Val))/binary>> || Val <- Vals >>,
     <<(length(Vals)):?short, Bin/binary>>;
 
@@ -523,6 +523,7 @@ result_kind(16#05) -> schema_change.
 
 flag(values, undefined)                   -> 0;
 flag(values, [])                          -> 0;
+flag(values, [null|_])                    -> 0;
 flag(values, [Val|_]) when is_binary(Val) -> 0;
 flag(values, [Val|_]) when is_tuple(Val)  -> 1.
 

--- a/src/ecql_types.erl
+++ b/src/ecql_types.erl
@@ -39,24 +39,24 @@
 name(?TYPE_CUSTOM)   -> custom;
 name(?TYPE_ASCII)    -> ascii;
 name(?TYPE_BIGINT)   -> bigint;
-name(?TYPE_BLOB)     -> blob; 
+name(?TYPE_BLOB)     -> blob;
 name(?TYPE_BOOLEAN)  -> boolean;
 name(?TYPE_COUNTER)  -> counter;
 name(?TYPE_DECIMAL)  -> decimal;
-name(?TYPE_DOUBLE)   -> double; 
-name(?TYPE_FLOAT)    -> float; 
+name(?TYPE_DOUBLE)   -> double;
+name(?TYPE_FLOAT)    -> float;
 name(?TYPE_INT)      -> int;
-name(?TYPE_TIMESTAMP)-> timestamp; 
+name(?TYPE_TIMESTAMP)-> timestamp;
 name(?TYPE_UUID)     -> uuid;
 name(?TYPE_VARCHAR)  -> varchar;
-name(?TYPE_VARINT)   -> varint; 
+name(?TYPE_VARINT)   -> varint;
 name(?TYPE_TIMEUUID) -> timeuuid;
-name(?TYPE_INET)     -> inet; 
-name(?TYPE_LIST)     -> list; 
-name(?TYPE_MAP)      -> map; 
+name(?TYPE_INET)     -> inet;
+name(?TYPE_LIST)     -> list;
+name(?TYPE_MAP)      -> map;
 name(?TYPE_SET)      -> set;
 name(?TYPE_UDT)      -> udt;
-name(?TYPE_TUPLE)    -> tuple. 
+name(?TYPE_TUPLE)    -> tuple.
 
 value(custom)        -> ?TYPE_CUSTOM;
 value(ascii)         -> ?TYPE_ASCII;
@@ -87,6 +87,8 @@ is_type(T) ->
 %% Encode
 %%------------------------------------------------------------------------------
 
+encode(null) ->
+    null;
 encode(A) when is_atom(A) ->
     encode(text, atom_to_list(A));
 encode(L) when is_list(L) ->
@@ -180,6 +182,8 @@ encode({tuple, Types}, Tuple) ->
     Encode = fun(Type, El) -> to_bytes(encode(Type, El)) end,
     << <<(Encode(Type, El))/binary>> || {Type, El} <- L >>.
 
+to_bytes(null) ->
+    <<-1:32/big-signed-integer>>;
 to_bytes(Bin) ->
     <<(size(Bin)):?int, Bin/binary>>.
 
@@ -272,4 +276,3 @@ decode({tuple, ElTypes}, Size, Bin) ->
 
 from_bytes(<<Size:?int, Bin:Size/binary, Rest/binary>>) ->
     {Bin, Rest}.
-

--- a/test/ecql_frame_tests.erl
+++ b/test/ecql_frame_tests.erl
@@ -141,4 +141,3 @@ serialize_query_test() ->
     ecql_frame:serialize_req(Query).
 
 -endif.
-

--- a/test/ecql_proto_tests.erl
+++ b/test/ecql_proto_tests.erl
@@ -81,7 +81,32 @@ query_test() ->
                                                consistency = ?CL_ONE,
                                                values = [<<1:?int>>, <<2:?int>>, <<3:?int>>]}},
     {Frame3, State3} = ecql_proto:query(<<"select">>, ?CL_ONE, [{int, 1}, {int, 2}, {int, 3}], State2),
-    ?assertEqual(FrameC, Frame3).
+    ?assertEqual(FrameC, Frame3),
+
+    {Frame4, _} = ecql_proto:query(<<"select">>, ?CL_ONE, [<<"text">>, {int, 1}, atom, null],
+                                        State),
+    ?assertMatch(
+       #ecql_frame{
+          message = #ecql_query{values = [ <<"text">>
+                                         , BinInt
+                                         , <<"atom">>
+                                         , null
+                                         ]}
+         } when is_binary(BinInt),
+       Frame4),
+    _ = ecql_frame:serialize(Frame4),
+
+    %% Only nulls
+    {Frame5, _} = ecql_proto:query(<<"select">>, ?CL_ONE, [null, null, null],
+                                        State),
+    ?assertMatch(
+       #ecql_frame{
+          message = #ecql_query{values = [null, null, null]}
+         },
+       Frame5),
+    _ = ecql_frame:serialize(Frame5),
+
+    ok.
 
 execute_test() ->
     State = init(),
@@ -108,4 +133,3 @@ register_test() ->
     ?assertMatch({Frame, _}, ecql_proto:register([<<"SCHEMA_CHANGE">>], State)).
 
 -endif.
-

--- a/test/ecql_proto_tests.erl
+++ b/test/ecql_proto_tests.erl
@@ -106,6 +106,62 @@ query_test() ->
        Frame5),
     _ = ecql_frame:serialize(Frame5),
 
+    {Frame6, _} = ecql_proto:batch(
+                    #ecql_batch{
+                       consistency = ?CL_ONE,
+                       queries =
+                           [ #ecql_batch_query{
+                                kind = ?BATCH_QUERY_KIND_PREPARED_ID,
+                                query_or_id = <<19,4,11,242,254,138,108,237,216,180,240,
+                                                1,68,36,120,219>>,
+                                values = [<<"text">>, {int, 1}, atom, null]
+                               }
+                           ]
+                      },
+                    State),
+    ?assertMatch(
+       #ecql_frame{
+          message = #ecql_batch{
+                       queries = [#ecql_batch_query{
+                                     values = [ <<"text">>
+                                              , BinInt
+                                              , <<"atom">>
+                                              , null
+                                              ]
+                                    }]
+                      }
+         } when is_binary(BinInt),
+       Frame6),
+    _ = ecql_frame:serialize(Frame6),
+
+    %% only nulls
+    {Frame7, _} = ecql_proto:batch(
+                    #ecql_batch{
+                       consistency = ?CL_ONE,
+                       queries =
+                           [ #ecql_batch_query{
+                                kind = ?BATCH_QUERY_KIND_PREPARED_ID,
+                                query_or_id = <<19,4,11,242,254,138,108,237,216,180,240,
+                                                1,68,36,120,219>>,
+                                values = [null, null, null]
+                               }
+                           ]
+                      },
+                    State),
+    ?assertMatch(
+       #ecql_frame{
+          message = #ecql_batch{
+                       queries = [#ecql_batch_query{
+                                     values = [ null
+                                              , null
+                                              , null
+                                              ]
+                                    }]
+                      }
+         },
+       Frame7),
+    _ = ecql_frame:serialize(Frame7),
+
     ok.
 
 execute_test() ->

--- a/test/ecql_types_tests.erl
+++ b/test/ecql_types_tests.erl
@@ -92,7 +92,7 @@ encode_decode_test() ->
 
     Set = [1, 2, 3],
     SetBin = encode({set, bigint}, Set),
-    ?assertMatch({Set, <<>>}, decode({set, bigint}, size(SetBin), SetBin)), 
+    ?assertMatch({Set, <<>>}, decode({set, bigint}, size(SetBin), SetBin)),
 
     {MegaSecs, Secs, _MicroSecs} = os:timestamp(),
     Timestamp = MegaSecs * 1000000 + Secs,
@@ -111,6 +111,11 @@ encode_decode_test() ->
     Tuple = {1, <<"haha">>, 2},
     Types = {bigint, text, counter},
     TupleBin = encode({tuple, Types}, Tuple),
-    ?assertEqual({Tuple, <<>>}, decode({tuple, Types}, size(TupleBin), TupleBin)).
+    ?assertEqual({Tuple, <<>>}, decode({tuple, Types}, size(TupleBin), TupleBin)),
+
+    EncodedNull = ecql_types:to_bytes(ecql_types:encode(null)),
+    ?assertEqual(<<-1:32/big-signed-integer>>, EncodedNull),
+
+    ok.
 
 -endif.


### PR DESCRIPTION
Before this fix, we had no way of inserting `NULL` values when executing queries/statements.  This was particularly strange for `int` fields, as they would contain the number `1853189228`, which is `<<"null">>`.

Now, we send a `null` atom to insert such values.