### PR TITLE
fix: Fix the prepared query cannot be modified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ erlang.mk
 _build
 rebar.lock
 *.swp
+.DS_Store

--- a/src/ecql.app.src
+++ b/src/ecql.app.src
@@ -1,7 +1,7 @@
 {application, ecql,
  [
   {description, "Cassandra Native CQL Driver"},
-  {vsn, "0.7.0"},
+  {vsn, "0.7.1"},
   {modules, []},
   {registered, []},
   {applications, [


### PR DESCRIPTION
part of https://emqx.atlassian.net/browse/EMQX-13218

Before the fix, when the SQL Teamples in EMQX Action were modified, ecql could not prepare the new SQL statement to Cassandra with the same PrepareKey.